### PR TITLE
ci: Use ACTIONS_GET_PR for changelog token retrieval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         id: changelog
         uses: mikepenz/release-changelog-builder-action@v4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_GET_PR }}
 
       - name: Create GitHub Release
         if: ${{ steps.extract_branch.outputs.branch == 'main' || steps.extract_branch.outputs.branch == 'dev' }}


### PR DESCRIPTION
- Update token retrieval in release workflow to use `ACTIONS_GET_PR` secret instead of `GITHUB_TOKEN`.