### PR TITLE
test: Add validation for event listener methods +semver:patch

### DIFF
--- a/TTT/Game/EventBus.cs
+++ b/TTT/Game/EventBus.cs
@@ -32,6 +32,10 @@ public class EventBus : IEventBus {
       dirtyTypes.Add(eventType);
     }
 
+    if (dirtyTypes.Count == 0)
+      throw new InvalidOperationException(
+        $"Listener {listener.GetType().Name} has no valid event handlers.");
+
     // Sort handlers by priority
     foreach (var type in dirtyTypes)
       handlers[type]

--- a/TTT/Test/Game/Event/EventBusTest.cs
+++ b/TTT/Test/Game/Event/EventBusTest.cs
@@ -64,4 +64,22 @@ public class EventBusTest(IEventBus bus) {
     Assert.False(ev.IsCanceled);
     Assert.Equal(2, listener.Fired);
   }
+
+  [Fact]
+  public void Register_Throws_IfNoMethods() {
+    Assert.Throws<InvalidOperationException>(()
+      => bus.RegisterListener(new InvalidListeners.NoMethodListener()));
+  }
+
+  [Fact]
+  public void Register_Throws_IfNoParams() {
+    Assert.Throws<InvalidOperationException>(()
+      => bus.RegisterListener(new InvalidListeners.NoParamListener()));
+  }
+
+  [Fact]
+  public void Register_Throws_IfWrongParam() {
+    Assert.Throws<InvalidOperationException>(()
+      => bus.RegisterListener(new InvalidListeners.WrongParamListener()));
+  }
 }

--- a/TTT/Test/Game/Event/InvalidListeners.cs
+++ b/TTT/Test/Game/Event/InvalidListeners.cs
@@ -1,0 +1,27 @@
+using TTT.API.Events;
+
+namespace TTT.Test.Game.Event;
+
+public static class InvalidListeners {
+  public class NoMethodListener : IListener {
+    public void Dispose() { }
+  }
+
+  public class NoParamListener : IListener {
+    [EventHandler]
+    public void OnEvent() {
+      // No parameters, should throw
+    }
+
+    public void Dispose() { }
+  }
+
+  public class WrongParamListener : IListener {
+    [EventHandler]
+    public void OnEvent(string message) {
+      // Invalid parameter type, should throw
+    }
+
+    public void Dispose() { }
+  }
+}


### PR DESCRIPTION
```
- Introduce InvalidListeners.cs to define and test invalid event listener scenarios.
- Add validation in EventBus to ensure listeners have valid event handler methods, throwing `InvalidOperationException` if invalid.
- Extend EventBusTest with new test cases for invalid listener registration, covering cases with no methods, no parameters, and incorrect parameters.
```