### PR TITLE
feat: Add Silent AWP item +semver:minor (resolves #105)

### DIFF
--- a/TTT/CS2/Command/Test/GiveItemCommand.cs
+++ b/TTT/CS2/Command/Test/GiveItemCommand.cs
@@ -44,6 +44,7 @@ public class GiveItemCommand(IServiceProvider provider) : ICommand {
         target = result;
       }
 
+      item.OnPurchase(target);
       shop.GiveItem(target, item);
       info.ReplySync($"Gave item '{item.Name}' to {target.Name}.");
     });

--- a/TTT/CS2/Command/Test/IndexCommand.cs
+++ b/TTT/CS2/Command/Test/IndexCommand.cs
@@ -16,7 +16,8 @@ public class IndexCommand : ICommand {
 
     Server.NextWorldUpdate(() => {
       foreach (var player in Utilities.GetPlayers())
-        info.ReplySync($"{player.PlayerName} - {player.Slot}");
+        info.ReplySync(
+          $"{player.PlayerName} - {player.Slot} {player.Index} {player.DraftIndex} {player.PawnCharacterDefIndex}");
     });
 
     return Task.FromResult(CommandResult.SUCCESS);

--- a/TTT/CS2/Items/SilentAWP/SilentAWPItem.cs
+++ b/TTT/CS2/Items/SilentAWP/SilentAWPItem.cs
@@ -1,0 +1,103 @@
+﻿using System.Numerics;
+using CounterStrikeSharp.API;
+using CounterStrikeSharp.API.Core;
+using CounterStrikeSharp.API.Core.Attributes.Registration;
+using CounterStrikeSharp.API.Modules.UserMessages;
+using JetBrains.Annotations;
+using Microsoft.Extensions.DependencyInjection;
+using ShopAPI;
+using ShopAPI.Configs;
+using ShopAPI.Configs.Traitor;
+using TTT.API;
+using TTT.API.Extensions;
+using TTT.API.Player;
+using TTT.API.Storage;
+using TTT.CS2.Extensions;
+using TTT.CS2.RayTrace.Class;
+using TTT.Game.Roles;
+using Vector = CounterStrikeSharp.API.Modules.Utils.Vector;
+
+namespace TTT.CS2.Items.SilentAWP;
+
+public static class SilentAWPServiceCollection {
+  public static void AddSilentAWPServices(this IServiceCollection services) {
+    services.AddModBehavior<SilentAWPItem>();
+  }
+}
+
+public class SilentAWPItem(IServiceProvider provider)
+  : RoleRestrictedItem<TraitorRole>(provider), IPluginModule {
+  public override string Name => Locale[SilentAWPMsgs.SHOP_ITEM_SILENT_AWP];
+
+  public override string Description
+    => Locale[SilentAWPMsgs.SHOP_ITEM_SILENT_AWP_DESC];
+
+  public override ShopItemConfig Config => config;
+
+  private readonly SilentAWPConfig config =
+    provider.GetService<IStorage<SilentAWPConfig>>()
+    ?.Load()
+     .GetAwaiter()
+     .GetResult() ?? new SilentAWPConfig();
+
+  public override void OnPurchase(IOnlinePlayer player) {
+    silentShots[player] = config.CurrentAmmo ?? 0 + config.ReserveAmmo ?? 0;
+    Inventory.GiveWeapon(player, config);
+  }
+
+  private readonly IDictionary<IOnlinePlayer, int> silentShots =
+    new Dictionary<IOnlinePlayer, int>();
+
+  private readonly IPlayerConverter<CCSPlayerController> playerConverter =
+    provider.GetRequiredService<IPlayerConverter<CCSPlayerController>>();
+
+  public void Start(BasePlugin? plugin) {
+    base.Start();
+    plugin?.HookUserMessage(452, onWeaponSound);
+  }
+
+  private HookResult onWeaponSound(UserMessage msg) {
+    var defIndex = msg.ReadUInt("item_def_index");
+
+    if (config.WeaponIndex != defIndex) return HookResult.Continue;
+    var splits = msg.DebugString.Split("\n");
+    if (splits.Length < 5) return HookResult.Continue;
+    var angleLines = msg.DebugString.Split("\n")[1..4]
+     .Select(s => s.Trim())
+     .ToList();
+    if (!angleLines[0].Contains('x') || !angleLines[1].Contains('y')
+      || !angleLines[2].Contains('z'))
+      return HookResult.Continue;
+    var x      = float.Parse(angleLines[0].Split(' ')[1]);
+    var y      = float.Parse(angleLines[1].Split(' ')[1]);
+    var z      = float.Parse(angleLines[2].Split(' ')[1]);
+    var vec    = new Vector(x, y, z);
+    var player = findPlayerByCoord(vec);
+
+    if (player == null) return HookResult.Continue;
+    if (playerConverter.GetPlayer(player) is not IOnlinePlayer apiPlayer)
+      return HookResult.Continue;
+
+    if (!silentShots.TryGetValue(apiPlayer, out var shots) || shots <= 0)
+      return HookResult.Continue;
+
+    silentShots[apiPlayer] = shots - 1;
+    if (silentShots[apiPlayer] == 0) {
+      silentShots.Remove(apiPlayer);
+      Shop.RemoveItem<SilentAWPItem>(apiPlayer);
+    }
+
+    return HookResult.Handled;
+  }
+
+  private CCSPlayerController? findPlayerByCoord(Vector vec) {
+    foreach (var pl in Utilities.GetPlayers()) {
+      var origin = pl.GetEyePosition();
+      if (origin == null) continue;
+      var dist = vec.DistanceSquared(origin);
+      if (dist < 1) return pl;
+    }
+
+    return null;
+  }
+}

--- a/TTT/CS2/Items/SilentAWP/SilentAWPMsgs.cs
+++ b/TTT/CS2/Items/SilentAWP/SilentAWPMsgs.cs
@@ -1,0 +1,11 @@
+﻿using TTT.Locale;
+
+namespace TTT.CS2.Items.SilentAWP;
+
+public class SilentAWPMsgs {
+  public static IMsg SHOP_ITEM_SILENT_AWP
+    => MsgFactory.Create(nameof(SHOP_ITEM_SILENT_AWP));
+
+  public static IMsg SHOP_ITEM_SILENT_AWP_DESC
+    => MsgFactory.Create(nameof(SHOP_ITEM_SILENT_AWP_DESC));
+}

--- a/TTT/CS2/Player/CS2AliveSpoofer.cs
+++ b/TTT/CS2/Player/CS2AliveSpoofer.cs
@@ -53,7 +53,7 @@ public class CS2AliveSpoofer : IAliveSpoofer, IPluginModule {
   }
 
   private void onTick() {
-    _fakeAlivePlayers.RemoveWhere(p => !p.IsValid);
+    _fakeAlivePlayers.RemoveWhere(p => !p.IsValid || p.Handle == IntPtr.Zero);
     foreach (var player in _fakeAlivePlayers) {
       player.PawnIsAlive = true;
       Utilities.SetStateChanged(player, "CCSPlayerController",

--- a/TTT/CS2/lang/en.yml
+++ b/TTT/CS2/lang/en.yml
@@ -33,3 +33,6 @@ SHOP_ITEM_ARMOR_DESC: "Wear armor that reduces incoming damage."
 
 SHOP_ITEM_ONE_HIT_KNIFE: "One-Hit Knife"
 SHOP_ITEM_ONE_HIT_KNIFE_DESC: "Your next knife hit will be a guaranteed kill."
+
+SHOP_ITEM_SILENT_AWP: "Silent AWP"
+SHOP_ITEM_SILENT_AWP_DESC: "Receive a silenced AWP with limited ammo."

--- a/TTT/Shop/ShopServiceCollection.cs
+++ b/TTT/Shop/ShopServiceCollection.cs
@@ -8,6 +8,7 @@ using TTT.CS2.Items.DNA;
 using TTT.CS2.Items.OneHitKnife;
 using TTT.CS2.Items.PoisonShots;
 using TTT.CS2.Items.PoisonSmoke;
+using TTT.CS2.Items.SilentAWP;
 using TTT.CS2.Items.Station;
 using TTT.Shop.Commands;
 using TTT.Shop.Items;
@@ -49,6 +50,7 @@ public static class ShopServiceCollection {
     collection.AddOneHitKnifeService();
     collection.AddPoisonShots();
     collection.AddPoisonSmoke();
+    collection.AddSilentAWPServices();
     collection.AddStickerServices();
     collection.AddTaserItem();
   }

--- a/TTT/ShopAPI/BaseItem.cs
+++ b/TTT/ShopAPI/BaseItem.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using ShopAPI.Configs;
+using TTT.API.Messages;
 using TTT.API.Player;
 using TTT.API.Role;
 using TTT.Locale;
@@ -17,6 +18,9 @@ public abstract class BaseItem(IServiceProvider provider) : IShopItem {
 
   protected readonly IRoleAssigner Roles =
     provider.GetRequiredService<IRoleAssigner>();
+  
+  protected readonly IMessenger Messenger =
+    provider.GetRequiredService<IMessenger>();
 
   protected readonly IShop Shop = provider.GetRequiredService<IShop>();
 

--- a/TTT/ShopAPI/Configs/Traitor/SilentAWPConfig.cs
+++ b/TTT/ShopAPI/Configs/Traitor/SilentAWPConfig.cs
@@ -1,0 +1,11 @@
+﻿using TTT.API;
+
+namespace ShopAPI.Configs.Traitor;
+
+public record SilentAWPConfig : ShopItemConfig, IWeapon {
+  public override int Price { get; init; }
+  public string WeaponId { get; } = "weapon_awp";
+  public int? ReserveAmmo { get; } = 0;
+  public int? CurrentAmmo { get; } = 2;
+  public int WeaponIndex { get; } = 9;
+}


### PR DESCRIPTION
- Implement Silent AWP item functionality with `SilentAWPServiceCollection` and `SilentAWPItem` class for `TraitorRole`
- Add Silent AWP shop item and related localized texts in `en.yml`
- Define message constants for Silent AWP in `SilentAWPMsgs.cs` for internationalization
- Modify `GiveItemCommand.cs` to incorporate `OnPurchase` logic for item purchases
- Manage player validity in `CS2AliveSpoofer.cs` by removing players with null handles
- Enhance player detail replies in `IndexCommand.cs`
- Introduce messaging functionality in `BaseItem.cs` and use via `Messenger` field
- Add Silent AWP service integration in `ShopServiceCollection.cs` and `Traitor` config in `SilentAWPConfig.cs`